### PR TITLE
Fixed rotation during jumps

### DIFF
--- a/Assets/Scripts/AgentLinkMover.cs
+++ b/Assets/Scripts/AgentLinkMover.cs
@@ -15,6 +15,7 @@ public class AgentLinkMover : MonoBehaviour
 {
     public OffMeshLinkMoveMethod m_Method = OffMeshLinkMoveMethod.Parabola;
     public AnimationCurve m_Curve = new AnimationCurve();
+    public bool fixRotationJumping = true;
 
     IEnumerator Start()
     {
@@ -24,6 +25,11 @@ public class AgentLinkMover : MonoBehaviour
         {
             if (agent.isOnOffMeshLink)
             {
+                if(fixRotationJumping)
+                {
+                    transform.rotation = Quaternion.LookRotation((agent.destination - agent.transform.position).normalized);
+                }
+
                 if (m_Method == OffMeshLinkMoveMethod.NormalSpeed)
                     yield return StartCoroutine(NormalSpeed(agent));
                 else if (m_Method == OffMeshLinkMoveMethod.Parabola)
@@ -31,6 +37,11 @@ public class AgentLinkMover : MonoBehaviour
                 else if (m_Method == OffMeshLinkMoveMethod.Curve)
                     yield return StartCoroutine(Curve(agent, 0.5f));
                 agent.CompleteOffMeshLink();
+
+                if(fixRotationJumping)
+                {
+                    transform.rotation = Quaternion.LookRotation((agent.destination - agent.transform.position).normalized);
+                }
             }
             yield return null;
         }


### PR DESCRIPTION
The ant was rotating to the side when entering NavMeshLink.

Added a few lines in AgentLinkMover to fix that.