### PR TITLE
Removed liquid when no ammo

### DIFF
--- a/Assets/Scripts/Wobble.cs
+++ b/Assets/Scripts/Wobble.cs
@@ -56,6 +56,7 @@ public class Wobble : MonoBehaviour
 
         // Debug.Log(rend.material.GetFloat("Fill"));
         rend.material.SetFloat("Fill", controller.GetAmmoRatio());
+        rend.enabled = controller.GetAmmoRatio() != 0.0f;
         
     }
 


### PR DESCRIPTION
When the pistol had 0 ammo, the liquid was still there.
Now the Renderer component is disabled when ammo == 0.